### PR TITLE
purge all cache when resetCache is true.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Creates redux middleware.
             * `state` *(Object)*: The current state of the Store.
         * Returns:
             * *(Boolean)*: If `true`, saves the obtaining resource to cache.
+    * `resetCache` *(Function)*: reset cache if resetCache function returns true.
+      Defaults `() => false`.
+        * Arguments:
+            * `action` *(Object)*: An action.
+            * `state` *(Object)*: The current state of the Store.
+        * Returns:
+            * *(Boolean)*: If `true`, reset all cache.
 
 ##### Returns
 

--- a/test/fixtures/actions.js
+++ b/test/fixtures/actions.js
@@ -19,6 +19,26 @@ export const fetchUser1Action = {
   },
 };
 
+export const createDiaryAction = {
+  type: FETCHR,
+  payload: {
+    type: 'create',
+    resource: 'diary',
+    params: {
+      title: 'foo',
+      content: 'bar',
+    },
+  },
+};
+
+export const fetchDiaryAction = {
+  type: FETCHR,
+  payload: {
+    type: 'read',
+    resource: 'diary',
+  },
+};
+
 export const fetchProductsAction = {
   type: FETCHR,
   payload: {

--- a/test/fixtures/createDataStore.js
+++ b/test/fixtures/createDataStore.js
@@ -1,0 +1,27 @@
+import { createStore, applyMiddleware } from 'redux';
+import fetchrCacheMiddleware, { FETCHR } from '../../src';
+
+export const data = [];
+
+function fetchrMiddleeware({ dispatch }) {
+  return (next) => (action) => {
+    if (action.type !== FETCHR) {
+      return next(action);
+    }
+
+    if (action.payload.type === 'create') {
+      data.push(action.payload.params);
+    }
+
+    return Promise.resolve(dispatch({
+      type: 'FETCHR_SUCCESS',
+      payload: [...data],
+    }));
+  };
+}
+
+export default function (options) {
+  return createStore(() => {
+  }, {}, applyMiddleware(fetchrCacheMiddleware({}, options), fetchrMiddleeware));
+}
+

--- a/test/resetCache.js
+++ b/test/resetCache.js
@@ -1,0 +1,43 @@
+import { test } from 'eater/runner';
+import assert from 'assert';
+import createDataStore from './fixtures/createDataStore';
+import { createDiaryAction, fetchDiaryAction } from './fixtures/actions';
+
+test('resetCache: always false => cache all', () => {
+  const resetCache = false;
+  const store = createDataStore({ resetCache: () => resetCache });
+  store.dispatch(fetchDiaryAction).then((result) => Promise.all([
+    store.dispatch(createDiaryAction),
+    store.dispatch(createDiaryAction),
+  ]), assert.fail).then((results) => store.dispatch(fetchDiaryAction)
+  ).then((result) => {
+    assert.deepStrictEqual(result.payload, []);
+  }, assert.fail);
+});
+
+test('resetCache: always true => always reset cache', () => {
+  const resetCache = true;
+  const store = createDataStore({ resetCache: () => resetCache });
+  store.dispatch(fetchDiaryAction).then((result) => Promise.all([
+    store.dispatch(createDiaryAction),
+    store.dispatch(createDiaryAction),
+  ]), assert.fail).then((results) => store.dispatch(fetchDiaryAction)
+  ).then((result) => {
+    assert.deepStrictEqual(result.payload, 
+      [{ title: 'foo', content: 'bar' }, { title: 'foo', content: 'bar' }]);
+  }, assert.fail);
+});
+
+test('resetCache: read always uses cache, but create purges the cache result', () => {
+  const resetCache = (action) => action.payload.type !== 'read';
+  const store = createDataStore({ resetCache });
+  store.dispatch(fetchDiaryAction).then(
+    (result) => store.dispatch(createDiaryAction), assert.fail
+  ).then(
+    (result) => store.dispatch(fetchDiaryAction), assert.fail
+  ).then(
+    (result) => assert.deepStrictEqual(result.payload, 
+      [{ title: 'foo', content: 'bar' }]), assert.fail
+  );
+});
+


### PR DESCRIPTION
I would like to purge cache a condition is fulfilled. For example, create/update/delete request is called, the cache will be staled. current default behavior is `all read request is cache on 10mins`. this behavior is not suit on our apps. 