### PR TITLE
feat: add resetCacheData to reset cache

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,27 @@
-import createCache from 'lru-cache';
+import lruCache from 'lru-cache';
 
 /*
  * Action types
  */
 export const FETCHR = 'EFFECT_FETCHR';
 
+let cacheInstance = null;
+
+/*
+ * Factory Method for cache instance (singleton)
+ */
+function createCache(cacheConfig = {}) {
+  if (cacheInstance !== null) {
+    return cacheInstance;
+  }
+
+  cacheInstance = lruCache(cacheConfig);
+  return cacheInstance;
+}
+
 /*
  * Middleware
  */
-
 export default function fetchrCacheMiddleware(cacheConfig = {}, options = {}) {
   const cache = createCache(cacheConfig);
   const { excludes, fromCache, toCache, resetCache } = options;
@@ -43,4 +56,9 @@ export default function fetchrCacheMiddleware(cacheConfig = {}, options = {}) {
       return result;
     });
   };
+}
+
+export function resetCacheData() {
+  const cache = createCache();
+  cache.reset();
 }

--- a/test/resetCache.js
+++ b/test/resetCache.js
@@ -2,6 +2,7 @@ import { test } from 'eater/runner';
 import assert from 'assert';
 import createDataStore from './fixtures/createDataStore';
 import { createDiaryAction, fetchDiaryAction } from './fixtures/actions';
+import { resetCacheData } from '../src/';
 
 test('resetCache: always false => cache all', () => {
   const resetCache = false;
@@ -23,7 +24,7 @@ test('resetCache: always true => always reset cache', () => {
     store.dispatch(createDiaryAction),
   ]), assert.fail).then((results) => store.dispatch(fetchDiaryAction)
   ).then((result) => {
-    assert.deepStrictEqual(result.payload, 
+    assert.deepStrictEqual(result.payload,
       [{ title: 'foo', content: 'bar' }, { title: 'foo', content: 'bar' }]);
   }, assert.fail);
 });
@@ -36,7 +37,22 @@ test('resetCache: read always uses cache, but create purges the cache result', (
   ).then(
     (result) => store.dispatch(fetchDiaryAction), assert.fail
   ).then(
-    (result) => assert.deepStrictEqual(result.payload, 
+    (result) => assert.deepStrictEqual(result.payload,
+      [{ title: 'foo', content: 'bar' }]), assert.fail
+  );
+});
+
+test('resetAllCache: use exposed resetAllCache function', () => {
+  const store = createDataStore();
+  store.dispatch(fetchDiaryAction).then(
+    (result) => {
+      store.dispatch(createDiaryAction);
+      resetCacheData();
+    }, assert.fail
+  ).then(
+    (result) => store.dispatch(fetchDiaryAction), assert.fail
+  ).then(
+    (result) => assert.deepStrictEqual(result.payload,
       [{ title: 'foo', content: 'bar' }]), assert.fail
   );
 });


### PR DESCRIPTION
I would like to add `resetCacheData` function to purge cache from other function.
We need to reset our cache when our data is changed by `not fetchr` data resource like websocket, sse etc. 